### PR TITLE
Update to new builder api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ First, we create a client and connect to the APNs development server:
 
 ;; Old-school certificate-based auth
 (with-open [cert (io/input-stream (File. "/path/to/cert.p12"))]
-  (def client (make-client cert "password")))
+  (def client (make-client :dev cert "password")))
+                    ;; use :prod in production env
 
 ;; New token-based auth
 (with-open [key (io/input-stream (File. "/path/to/key.p8"))]
-  (def client (make-client key "team-id" "key-id" ["topic-1" "topic-2"])))
+  (def client (make-client :dev key "team-id" "key-id")))
 
-(connect client :dev) ;; blocking operation, unlike Pushy
-                      ;; use :prod in production env
 ```
+
+Pushy is responsible for opening the connection to the specified
+server, and reopening it if anything causes it to close.
 
 Then we build a notification following Apple's [guidelines](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW1):
 

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.6"]
-                 [com.turo/pushy "0.11.1"]])
+                 [com.turo/pushy "0.11.3"]])


### PR DESCRIPTION
These changes have `pushy-clj` working again for me with the latest Pushy release in our code base. (I had to add the `host` argument to `make-client`, and remove the `connect` calls, as this is a breaking API change.)

I also removed the `topics` argument, because that was not being used (and does not seem to be supported by Pushy), but am I missing something?