### PR TITLE
Add invalidation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ First, we create a client and connect to the APNs development server:
 
 ;; Old-school certificate-based auth
 (with-open [cert (io/input-stream (File. "/path/to/cert.p12"))]
-  (def client (make-client cert "password")))
+  (def client (make-client :dev cert "password")))
+                    ;; use :prod in production env
 
 ;; New token-based auth
 (with-open [key (io/input-stream (File. "/path/to/key.p8"))]
-  (def client (make-client key "team-id" "key-id" ["topic-1" "topic-2"])))
+  (def client (make-client :dev key "team-id" "key-id")))
 
-(connect client :dev) ;; blocking operation, unlike Pushy
-                      ;; use :prod in production env
 ```
+
+Pushy is responsible for opening the connection to the specified
+server, and reopening it if anything causes it to close.
 
 Then we build a notification following Apple's [guidelines](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW1):
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pushy-clj "0.3.4-SNAPSHOT"
+(defproject pushy-clj "0.4.0"
   :description "A Clojure wrapper over Pushy for sending APNs push notifications."
   :url "https://github.com/divs1210/pushy-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.6"]
-                 [com.turo/pushy "0.11.1"]])
+                 [com.turo/pushy "0.11.3"]])

--- a/src/pushy_clj/core.clj
+++ b/src/pushy_clj/core.clj
@@ -7,7 +7,7 @@
            [com.turo.pushy.apns.auth ApnsSigningKey]
            io.netty.util.concurrent.Future
            java.io.InputStream
-           java.util.Collection
+           [java.util Collection Date]
            [java.util.concurrent TimeoutException TimeUnit]))
 
 (def ^:const apns-hosts
@@ -52,11 +52,17 @@
   "Returns a SimpleApnsPushNotification object.
   `token` is the device token
   `topic` if nil, will be picked from the cert
-  `payload` should be a hashmap that follows Apple's guidelines:  http://tinyurl.com/jj97ep6"
-  [^String token ^String topic payload]
-  (SimpleApnsPushNotification. (TokenUtil/sanitizeTokenString token)
-                               topic
-                               (build-payload payload)))
+  `payload` should be a hashmap that follows Apple's guidelines:  http://tinyurl.com/jj97ep6
+  `invalidation-time`, if present, is the timestamp after which delivery attempts should end"
+  ([^String token ^String topic payload]
+   (SimpleApnsPushNotification. (TokenUtil/sanitizeTokenString token)
+                                topic
+                                (build-payload payload)))
+  ([^String token ^String topic payload ^Date invalidation-time]
+   (SimpleApnsPushNotification. (TokenUtil/sanitizeTokenString token)
+                                topic
+                                (build-payload payload)
+                                invalidation-time)))
 
 
 (defn ^:private response->map


### PR DESCRIPTION
This goes beyond the API updates of the previous pull request to add the ability to set the `apns-expiration` header of a push, to tell APNS to retry delivery if the target device was unreachable when the push was initially sent.